### PR TITLE
Use prebuilt compose binaries from lsio repo

### DIFF
--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -18,7 +18,7 @@ jobs:
           fi
           echo "**** External trigger running off of master branch. To disable this trigger, set a Github secret named \"PAUSE_EXTERNAL_TRIGGER_CLOUD9_MASTER\". ****"
           echo "**** Retrieving external version ****"
-          EXT_RELEASE=$(curl -u "${{ secrets.CR_USER }}:${{ secrets.CR_PAT }}" -sX GET "https://api.github.com/repos/docker/compose/releases/latest" | jq -r '. | .tag_name')
+          EXT_RELEASE=$(curl -u "${{ secrets.CR_USER }}:${{ secrets.CR_PAT }}" -sX GET "https://api.github.com/repos/linuxserver/docker-docker-compose/releases/latest" | jq -r '. | .tag_name')
           if [ -z "${EXT_RELEASE}" ] || [ "${EXT_RELEASE}" == "null" ]; then
             echo "**** Can't retrieve external version, exiting ****"
             FAILURE_REASON="Can't retrieve external version for cloud9 branch master"

--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -18,7 +18,7 @@ jobs:
           fi
           echo "**** External trigger running off of master branch. To disable this trigger, set a Github secret named \"PAUSE_EXTERNAL_TRIGGER_CLOUD9_MASTER\". ****"
           echo "**** Retrieving external version ****"
-          EXT_RELEASE=$(curl -u "${{ secrets.CR_USER }}:${{ secrets.CR_PAT }}" -sX GET "https://api.github.com/repos/linuxserver/docker-docker-compose/releases/latest" | jq -r '. | .tag_name')
+          EXT_RELEASE=$(curl -u ${{ secrets.CR_USER }}:${{ secrets.CR_PAT }} -sX GET https://api.github.com/repos/linuxserver/docker-docker-compose/releases/latest | jq -r '.tag_name' | sed 's|-ls.*||')
           if [ -z "${EXT_RELEASE}" ] || [ "${EXT_RELEASE}" == "null" ]; then
             echo "**** Can't retrieve external version, exiting ****"
             FAILURE_REASON="Can't retrieve external version for cloud9 branch master"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,7 @@
-FROM ghcr.io/linuxserver/baseimage-ubuntu:bionic as buildstage
+ARG COMPOSE_VERSION="latest"
 
-ARG COMPOSE_VERSION
-
-RUN \
- echo "**** install packages ****" && \
- apt-get update && \
- apt-get install -y \
-	git \
-	libffi-dev \
-	python3 \
-	python3-dev \
-	python3-pip \
-	zlib1g-dev
-
-RUN \
- echo "**** build compose ****" && \
- cd /tmp && \
- if [ -z ${COMPOSE_VERSION+x} ]; then \
-	COMPOSE_VERSION=$(curl -sX GET "https://api.github.com/repos/docker/compose/releases/latest" \
-	| awk '/tag_name/{print $4;exit}' FS='[""]'); \
- fi && \
- git clone https://github.com/docker/compose.git && \
- cd compose && \
- git checkout ${COMPOSE_VERSION} && \
- pip3 install -U pip && \
- pip install \
-	pyinstaller && \
- pip install \
-	-r requirements.txt \
-	-r requirements-build.txt && \
- ./script/build/write-git-sha > compose/GITSHA && \
- pyinstaller docker-compose.spec && \
- mv dist/docker-compose /
+# docker compose
+FROM ghcr.io/linuxserver/docker-compose:amd64-${COMPOSE_VERSION} as compose
 
 # runtime stage
 FROM ghcr.io/linuxserver/baseimage-cloud9:latest
@@ -43,7 +13,7 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="thelamer"
 
 # Docker compose
-COPY --from=buildstage /docker-compose /usr/local/bin/
+COPY --from=compose /usr/local/bin/docker-compose /usr/local/bin/docker-compose
 
 RUN \
  echo "**** install docker deps ****" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-ARG COMPOSE_VERSION="latest"
+ARG COMPOSE_VERSION="1.29.2"
 
 # docker compose
-FROM ghcr.io/linuxserver/docker-compose:amd64-${COMPOSE_VERSION} as compose
+FROM ghcr.io/linuxserver/docker-compose:amd64-version-${COMPOSE_VERSION} as compose
 
 # runtime stage
 FROM ghcr.io/linuxserver/baseimage-cloud9:latest

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,38 +1,7 @@
-FROM ghcr.io/linuxserver/baseimage-ubuntu:arm64v8-bionic as buildstage
+ARG COMPOSE_VERSION="latest"
 
-ARG COMPOSE_VERSION
-
-RUN \
- echo "**** install packages ****" && \
- apt-get update && \
- apt-get install -y \
-	git \
-	libffi-dev \
-	libssl-dev \
-	python3 \
-	python3-dev \
-	python3-pip \
-	zlib1g-dev
-
-RUN \
- echo "**** build compose ****" && \
- cd /tmp && \
- if [ -z ${COMPOSE_VERSION+x} ]; then \
-	COMPOSE_VERSION=$(curl -sX GET "https://api.github.com/repos/docker/compose/releases/latest" \
-	| awk '/tag_name/{print $4;exit}' FS='[""]'); \
- fi && \
- git clone https://github.com/docker/compose.git && \
- cd compose && \
- git checkout ${COMPOSE_VERSION} && \
- pip3 install -U pip && \
- pip install \
-	pyinstaller && \
- pip install \
-	-r requirements.txt \
-	-r requirements-build.txt && \
- ./script/build/write-git-sha > compose/GITSHA && \
- pyinstaller docker-compose.spec && \
- mv dist/docker-compose /
+# docker compose
+FROM ghcr.io/linuxserver/docker-compose:arm64v8-${COMPOSE_VERSION} as compose
 
 # runtime stage
 FROM ghcr.io/linuxserver/baseimage-cloud9:arm64v8-latest
@@ -44,7 +13,7 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="thelamer"
 
 # Docker compose
-COPY --from=buildstage /docker-compose /usr/local/bin/
+COPY --from=compose /usr/local/bin/docker-compose /usr/local/bin/docker-compose
 
 RUN \
  echo "**** install docker deps ****" && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,7 +1,7 @@
-ARG COMPOSE_VERSION="latest"
+ARG COMPOSE_VERSION="1.29.2"
 
 # docker compose
-FROM ghcr.io/linuxserver/docker-compose:arm64v8-${COMPOSE_VERSION} as compose
+FROM ghcr.io/linuxserver/docker-compose:arm64v8-version-${COMPOSE_VERSION} as compose
 
 # runtime stage
 FROM ghcr.io/linuxserver/baseimage-cloud9:arm64v8-latest

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,7 +1,7 @@
-ARG COMPOSE_VERSION="latest"
+ARG COMPOSE_VERSION="1.29.2"
 
 # docker compose
-FROM ghcr.io/linuxserver/docker-compose:arm32v7-${COMPOSE_VERSION} as compose
+FROM ghcr.io/linuxserver/docker-compose:arm32v7-version-${COMPOSE_VERSION} as compose
 
 # runtime stage
 FROM ghcr.io/linuxserver/baseimage-cloud9:arm32v7-latest

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,39 +1,7 @@
-FROM ghcr.io/linuxserver/baseimage-ubuntu:arm32v7-bionic as buildstage
+ARG COMPOSE_VERSION="latest"
 
-ARG COMPOSE_VERSION
-
-RUN \
- echo "**** install packages ****" && \
- apt-get update && \
- apt-get install -y \
-	git \
-	libffi-dev \
-	libssl-dev \
-	python3 \
-	python3-dev \
-	python3-pip \
-	rustc \
-	zlib1g-dev
-
-RUN \
- echo "**** build compose ****" && \
- cd /tmp && \
- if [ -z ${COMPOSE_VERSION+x} ]; then \
-	COMPOSE_VERSION=$(curl -sX GET "https://api.github.com/repos/docker/compose/releases/latest" \
-	| awk '/tag_name/{print $4;exit}' FS='[""]'); \
- fi && \
- git clone https://github.com/docker/compose.git && \
- cd compose && \
- git checkout ${COMPOSE_VERSION} && \
- pip3 install -U pip && \
- pip install \
-	pyinstaller && \
- pip install \
-	-r requirements.txt \
-	-r requirements-build.txt && \
- ./script/build/write-git-sha > compose/GITSHA && \
- pyinstaller docker-compose.spec && \
- mv dist/docker-compose /
+# docker compose
+FROM ghcr.io/linuxserver/docker-compose:arm32v7-${COMPOSE_VERSION} as compose
 
 # runtime stage
 FROM ghcr.io/linuxserver/baseimage-cloud9:arm32v7-latest
@@ -45,7 +13,7 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="thelamer"
 
 # Docker compose
-COPY --from=buildstage /docker-compose /usr/local/bin/
+COPY --from=compose /usr/local/bin/docker-compose /usr/local/bin/docker-compose
 
 RUN \
  echo "**** install docker deps ****" && \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,8 +17,8 @@ pipeline {
     GITLAB_TOKEN=credentials('b6f0f1dd-6952-4cf6-95d1-9c06380283f0')
     GITLAB_NAMESPACE=credentials('gitlab-namespace-id')
     EXT_GIT_BRANCH = 'master'
-    EXT_USER = 'docker'
-    EXT_REPO = 'compose'
+    EXT_USER = 'linuxserver'
+    EXT_REPO = 'docker-docker-compose'
     BUILD_VERSION_ARG = 'COMPOSE_VERSION'
     LS_USER = 'linuxserver'
     LS_REPO = 'docker-cloud9'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,23 +101,16 @@ pipeline {
     /* ########################
        External Release Tagging
        ######################## */
-    // If this is a stable github release use the latest endpoint from github to determine the ext tag
-    stage("Set ENV github_stable"){
-     steps{
-       script{
-         env.EXT_RELEASE = sh(
-           script: '''curl -H "Authorization: token ${GITHUB_TOKEN}" -s https://api.github.com/repos/${EXT_USER}/${EXT_REPO}/releases/latest | jq -r '. | .tag_name' ''',
-           returnStdout: true).trim()
-       }
-     }
-    }
-    // If this is a stable or devel github release generate the link for the build message
-    stage("Set ENV github_link"){
-     steps{
-       script{
-         env.RELEASE_LINK = 'https://github.com/' + env.EXT_USER + '/' + env.EXT_REPO + '/releases/tag/' + env.EXT_RELEASE
-       }
-     }
+    // If this is a custom command to determine version use that command
+    stage("Set tag custom bash"){
+      steps{
+        script{
+          env.EXT_RELEASE = sh(
+            script: ''' curl -sX GET https://api.github.com/repos/linuxserver/docker-docker-compose/releases/latest | jq -r '.tag_name' | sed 's|-ls.*||' ''',
+            returnStdout: true).trim()
+            env.RELEASE_LINK = 'custom_command'
+        }
+      }
     }
     // Sanitize the release tag and strip illegal docker or github characters
     stage("Sanitize tag"){
@@ -800,11 +793,11 @@ pipeline {
              "tagger": {"name": "LinuxServer Jenkins","email": "jenkins@linuxserver.io","date": "'${GITHUB_DATE}'"}}' '''
         echo "Pushing New release for Tag"
         sh '''#! /bin/bash
-              curl -H "Authorization: token ${GITHUB_TOKEN}" -s https://api.github.com/repos/${EXT_USER}/${EXT_REPO}/releases/latest | jq '. |.body' | sed 's:^.\\(.*\\).$:\\1:' > releasebody.json
+              echo "Updating to ${EXT_RELEASE_CLEAN}" > releasebody.json
               echo '{"tag_name":"'${META_TAG}'",\
                      "target_commitish": "master",\
                      "name": "'${META_TAG}'",\
-                     "body": "**LinuxServer Changes:**\\n\\n'${LS_RELEASE_NOTES}'\\n\\n**'${EXT_REPO}' Changes:**\\n\\n' > start
+                     "body": "**LinuxServer Changes:**\\n\\n'${LS_RELEASE_NOTES}'\\n\\n**Remote Changes:**\\n\\n' > start
               printf '","draft": false,"prerelease": false}' >> releasebody.json
               paste -d'\\0' start releasebody.json > releasebody.json.done
               curl -H "Authorization: token ${GITHUB_TOKEN}" -X POST https://api.github.com/repos/${LS_USER}/${LS_REPO}/releases -d @releasebody.json.done'''

--- a/README.md
+++ b/README.md
@@ -246,5 +246,6 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **24.06.21:** - Use prebuilt compose binaries for the linuxserver repo.
 * **07.02.20:** - Add optional http auth.
 * **02.06.19:** - Initial Release.

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -8,8 +8,8 @@ release_tag: latest
 ls_branch: master
 repo_vars:
   - EXT_GIT_BRANCH = 'master'
-  - EXT_USER = 'docker'
-  - EXT_REPO = 'compose'
+  - EXT_USER = 'linuxserver'
+  - EXT_REPO = 'docker-docker-compose'
   - BUILD_VERSION_ARG = 'COMPOSE_VERSION'
   - LS_USER = 'linuxserver'
   - LS_REPO = 'docker-cloud9'

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -2,7 +2,8 @@
 
 # jenkins variables
 project_name: docker-cloud9
-external_type: github_stable
+external_type: na
+custom_version_command: "curl -sX GET https://api.github.com/repos/linuxserver/docker-docker-compose/releases/latest | jq -r '.tag_name' | sed 's|-ls.*||'"
 release_type: stable
 release_tag: latest
 ls_branch: master

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -50,6 +50,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "24.06.21:", desc: "Use prebuilt compose binaries for the linuxserver repo." }
   - { date: "07.02.20:", desc: "Add optional http auth." }
   - { date: "02.06.19:", desc: "Initial Release." }
 


### PR DESCRIPTION
~~I just realized that the version for this is going to include 2 `lsXX` tags, one from the docker compose repo and one from this one. I guess we can sed it out in the external trigger and use the `version-` endpoint, which should pull the same images~~
Avoiding double `lsXX` versioning